### PR TITLE
Fix missing ipaddress column in servers table

### DIFF
--- a/backend/models/Server.js
+++ b/backend/models/Server.js
@@ -13,7 +13,8 @@ module.exports = (sequelize, DataTypes) => {
     ipAddress: {
       type: DataTypes.STRING(45),
       allowNull: false,
-      unique: true
+      unique: true,
+      field: 'ip_address'
     },
     status: {
       type: DataTypes.ENUM('active', 'inactive', 'maintenance', 'error'),
@@ -22,51 +23,62 @@ module.exports = (sequelize, DataTypes) => {
     totalCpu: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      comment: 'Total CPU cores'
+      comment: 'Total CPU cores',
+      field: 'total_cpu'
     },
     totalMemory: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      comment: 'Total memory in GB'
+      comment: 'Total memory in GB',
+      field: 'total_memory'
     },
     totalStorage: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      comment: 'Total storage in GB'
+      comment: 'Total storage in GB',
+      field: 'total_storage'
     },
     allocatedCpu: {
       type: DataTypes.INTEGER,
       defaultValue: 0,
-      comment: 'Allocated CPU cores'
+      comment: 'Allocated CPU cores',
+      field: 'allocated_cpu'
     },
     allocatedMemory: {
       type: DataTypes.INTEGER,
       defaultValue: 0,
-      comment: 'Allocated memory in GB'
+      comment: 'Allocated memory in GB',
+      field: 'allocated_memory'
     },
     allocatedStorage: {
       type: DataTypes.INTEGER,
       defaultValue: 0,
-      comment: 'Allocated storage in GB'
+      comment: 'Allocated storage in GB',
+      field: 'allocated_storage'
     },
     osVersion: {
       type: DataTypes.STRING(50),
-      defaultValue: 'Rocky Linux 9'
+      defaultValue: 'Rocky Linux 9',
+      field: 'os_version'
     },
     sshPort: {
       type: DataTypes.INTEGER,
-      defaultValue: 22
+      defaultValue: 22,
+      field: 'ssh_port'
     },
     sshUser: {
       type: DataTypes.STRING(50),
-      defaultValue: 'root'
+      defaultValue: 'root',
+      field: 'ssh_user'
     },
     lastHealthCheck: {
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      field: 'last_health_check'
     },
     healthStatus: {
       type: DataTypes.ENUM('healthy', 'warning', 'critical'),
-      defaultValue: 'healthy'
+      defaultValue: 'healthy',
+      field: 'health_status'
     },
     metadata: {
       type: DataTypes.JSON,
@@ -81,13 +93,13 @@ module.exports = (sequelize, DataTypes) => {
       },
       {
         unique: true,
-        fields: ['ipAddress']
+        fields: ['ip_address']
       },
       {
         fields: ['status']
       },
       {
-        fields: ['healthStatus']
+        fields: ['health_status']
       }
     ]
   });

--- a/backend/models/VM.js
+++ b/backend/models/VM.js
@@ -13,7 +13,8 @@ module.exports = (sequelize, DataTypes) => {
     ipAddress: {
       type: DataTypes.STRING(45),
       allowNull: false,
-      unique: true
+      unique: true,
+      field: 'ip_address'
     },
     status: {
       type: DataTypes.ENUM('running', 'stopped', 'starting', 'stopping', 'error', 'provisioning'),
@@ -21,15 +22,18 @@ module.exports = (sequelize, DataTypes) => {
     },
     cpuCores: {
       type: DataTypes.INTEGER,
-      allowNull: false
+      allowNull: false,
+      field: 'cpu_cores'
     },
     memoryGb: {
       type: DataTypes.INTEGER,
-      allowNull: false
+      allowNull: false,
+      field: 'memory_gb'
     },
     storageGb: {
       type: DataTypes.INTEGER,
-      allowNull: false
+      allowNull: false,
+      field: 'storage_gb'
     },
     osImage: {
       type: DataTypes.ENUM(
@@ -37,29 +41,36 @@ module.exports = (sequelize, DataTypes) => {
         'rockylinux9', 'ubuntu20', 'ubuntu22', 
         'ubuntu24', 'oel8.10'
       ),
-      allowNull: false
+      allowNull: false,
+      field: 'os_image'
     },
     mountPoints: {
       type: DataTypes.JSON,
-      defaultValue: []
+      defaultValue: [],
+      field: 'mount_points'
     },
     sshKey: {
       type: DataTypes.TEXT,
-      allowNull: false
+      allowNull: false,
+      field: 'ssh_key'
     },
     defaultUser: {
       type: DataTypes.STRING(50),
-      defaultValue: 'acceldata'
+      defaultValue: 'acceldata',
+      field: 'default_user'
     },
     provisionedAt: {
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      field: 'provisioned_at'
     },
     lastHealthCheck: {
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      field: 'last_health_check'
     },
     healthStatus: {
       type: DataTypes.ENUM('healthy', 'warning', 'critical'),
-      defaultValue: 'healthy'
+      defaultValue: 'healthy',
+      field: 'health_status'
     },
     metadata: {
       type: DataTypes.JSON,
@@ -74,16 +85,16 @@ module.exports = (sequelize, DataTypes) => {
       },
       {
         unique: true,
-        fields: ['ipAddress']
+        fields: ['ip_address']
       },
       {
         fields: ['status']
       },
       {
-        fields: ['serverId']
+        fields: ['server_id']
       },
       {
-        fields: ['createdBy']
+        fields: ['created_by']
       }
     ]
   });


### PR DESCRIPTION
Map camelCase model fields to snake_case database columns in Server and VM Sequelize models to resolve schema mismatch.

This fixes the `ER_KEY_COLUMN_DOES_NOT_EXITS` error encountered during `db.sync({ alter: true })` by explicitly mapping model attributes like `ipAddress` to their corresponding database columns like `ip_address` using the `field` property in Sequelize. This ensures consistency between the application's ORM and the database schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-8aadfcc4-3534-4801-8dc9-e41bf1731c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8aadfcc4-3534-4801-8dc9-e41bf1731c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

